### PR TITLE
[Fix] 修正 chart 解析失敗

### DIFF
--- a/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/Chart.kt
+++ b/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/Chart.kt
@@ -1,11 +1,11 @@
 package net.makeagoodsoup.fugle_realtime_lib.core.entities
 
 data class Chart(
-    val averagePrices: List<Number>?, // 當日個股於此分鐘的成交均價
-    val openingPrices: List<Number>?, // 此分鐘的開盤價
-    val highestPrices: List<Number>?, // 此分鐘的最高價
-    val lowestPrices: List<Number>?, // 此分鐘的最低價
-    val closingPrices: List<Number>?, // 此分鐘的收盤價
-    val volumes: List<Number>?, // 此分鐘的成交量 (指數：金額；個股：張數；興櫃股票及零股：股數)
-    val times: List<Number>?, // Unix timestamp (每分鐘單位)
+    val averagePrices: List<Double>?, // 當日個股於此分鐘的成交均價
+    val openingPrices: List<Double>?, // 此分鐘的開盤價
+    val highestPrices: List<Double>?, // 此分鐘的最高價
+    val lowestPrices: List<Double>?, // 此分鐘的最低價
+    val closingPrices: List<Double>?, // 此分鐘的收盤價
+    val volumes: List<Double>?, // 此分鐘的成交量 (指數：金額；個股：張數；興櫃股票及零股：股數)
+    val times: List<Double>?, // Unix timestamp (每分鐘單位)
 )


### PR DESCRIPTION
發現用 Number 會解析失敗，如下圖：

<img width="1455" alt="Screen Shot 2023-01-03 at 6 53 24 PM" src="https://user-images.githubusercontent.com/21169170/210343599-3a669649-e933-4465-bd8d-777084268c91.png">

改回用 Double。