### PR TITLE
[Fixed] Downgrade gradle version for dart support.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.0' apply false
-    id 'com.android.library' version '7.4.0' apply false
+    id 'com.android.application' version '7.3.0' apply false
+    id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }


### PR DESCRIPTION
## Description

Flutter supports only Android Gradle Plugin `v7.3.0` (now is `v7.4.0`)

`v7.4.0` 專案開不起來，所以先降回去