### PR TITLE
[Changed] Update Sample App

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,15 +30,19 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = '1.8'
-    }
+
     buildFeatures {
         compose true
     }
+
     composeOptions {
         kotlinCompilerExtensionVersion '1.4.0'
     }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     packagingOptions {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -47,18 +51,35 @@ android {
 }
 
 dependencies {
+    def composeBom = platform('androidx.compose:compose-bom:2023.01.00')
+    implementation composeBom
+    androidTestImplementation composeBom
 
     implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'androidx.activity:activity-compose:1.6.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.1.0-alpha05'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1'
+    implementation 'androidx.compose.runtime:runtime-livedata'
+
+    // Compose
+    implementation "androidx.compose.runtime:runtime"
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material3:material3-window-size-class'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    // Compose testing dependencies
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    // Testing dependencies
+    androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.5.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+
+    // Fugle realtime dependency
     implementation project(path: ':fugle_realtime_lib')
-    testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     implementation composeBom
     androidTestImplementation composeBom
 
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.0"
     implementation 'androidx.core:core-ktx:1.9.0'
     implementation 'androidx.activity:activity-compose:1.6.1'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
     androidTestImplementation "androidx.test.espresso:espresso-contrib:3.5.1"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
+    testImplementation 'junit:junit:4.13.2'
 
     // Fugle realtime dependency
     implementation project(path: ':fugle_realtime_lib')

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/MainActivity.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/MainActivity.kt
@@ -5,14 +5,14 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.ExperimentalMaterial3Api
 import com.example.fugle_realtime_kotlin_sample.ui.MainScreen
-import com.example.fugle_realtime_kotlin_sample.ui.theme.FuglerealtimekotlinsampleTheme
+import com.example.fugle_realtime_kotlin_sample.ui.theme.FugleRealtimeKotlinSampleTheme
 
 @ExperimentalMaterial3Api
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            FuglerealtimekotlinsampleTheme {
+            FugleRealtimeKotlinSampleTheme {
                 MainScreen()
             }
         }

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/MainActivity.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/MainActivity.kt
@@ -3,86 +3,18 @@ package com.example.fugle_realtime_kotlin_sample
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import androidx.compose.material3.ExperimentalMaterial3Api
+import com.example.fugle_realtime_kotlin_sample.ui.MainScreen
 import com.example.fugle_realtime_kotlin_sample.ui.theme.FuglerealtimekotlinsampleTheme
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
-import net.makeagoodsoup.fugle_realtime_lib.core.repository.FugleHttpRepository
-import net.makeagoodsoup.fugle_realtime_lib.core.repository.successOr
 
+@ExperimentalMaterial3Api
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            Body()
-        }
-    }
-}
-
-val resultText = mutableStateOf("")
-
-@Composable()
-fun Body() {
-    return FuglerealtimekotlinsampleTheme {
-        // A surface container using the 'background' color from the theme
-        Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-            Column(
-                modifier = Modifier
-                    .padding(16.dp)
-                    .fillMaxSize()
-            ) {
-                SendHttpRequestButton()
-                Box(
-                    modifier = Modifier
-                        .height(16.dp)
-                        .fillMaxWidth()
-                )
-                TerminalText()
+            FuglerealtimekotlinsampleTheme {
+                MainScreen()
             }
         }
     }
-}
-
-@Composable
-fun SendHttpRequestButton() {
-    return Button(onClick = {
-        resultText.value = "InProgress"
-        GlobalScope.launch {
-            val result = FugleHttpRepository().getMeta("2884", "demo")
-            println("get meta: ${result.successOr(null)}")
-            resultText.value = "${result.successOr(null)}"
-        }
-    }) {
-        Text(text = "Get Meta")
-    }
-}
-
-@Composable
-fun TerminalText() {
-    val text by resultText
-    return Text(
-        text = text, color = Color.White, fontSize = 16.sp, modifier = Modifier
-            .background(color = Color.Black)
-            .fillMaxHeight()
-            .fillMaxWidth()
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    Body()
 }

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
@@ -1,0 +1,41 @@
+package com.example.fugle_realtime_kotlin_sample.data
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import net.makeagoodsoup.fugle_realtime_lib.core.repository.FugleHttpRepository
+import net.makeagoodsoup.fugle_realtime_lib.core.repository.successOr
+
+sealed class HttpData : RequestDelegate {
+
+    companion object {
+        fun values(): List<HttpData> = HttpData::class.sealedSubclasses.mapNotNull { it.objectInstance }
+    }
+
+    @DelicateCoroutinesApi
+    object Meta : HttpData() {
+        override fun name(): String = "Meta"
+
+        override fun start(symbolId: String, token: String, callback: (String) -> Unit) {
+            callback.invoke("InProgress")
+            GlobalScope.launch {
+                val result = FugleHttpRepository().getMeta(symbolId, token)
+                callback.invoke("${result.successOr(null)}")
+            }
+        }
+    }
+
+    @DelicateCoroutinesApi
+    object Quote : HttpData() {
+        override fun name(): String = "Quote"
+
+        override fun start(symbolId: String, token: String, callback: (String) -> Unit) {
+            callback.invoke("InProgress")
+            GlobalScope.launch {
+                val result = FugleHttpRepository().getQuote(symbolId, token)
+                callback.invoke("${result.successOr(null)}")
+            }
+        }
+    }
+    // TODO: more Http
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
@@ -3,6 +3,7 @@ package com.example.fugle_realtime_kotlin_sample.data
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.makeagoodsoup.fugle_realtime_lib.core.entities.stringify
 import net.makeagoodsoup.fugle_realtime_lib.core.repository.FugleHttpRepository
 import net.makeagoodsoup.fugle_realtime_lib.core.repository.successOr
 
@@ -20,7 +21,7 @@ sealed class HttpData : RequestDelegate {
             callback.invoke("InProgress")
             GlobalScope.launch {
                 val result = FugleHttpRepository().getMeta(symbolId, token)
-                callback.invoke("${result.successOr(null)}")
+                callback.invoke("${result.successOr(null)?.stringify()}")
             }
         }
     }
@@ -33,7 +34,7 @@ sealed class HttpData : RequestDelegate {
             callback.invoke("InProgress")
             GlobalScope.launch {
                 val result = FugleHttpRepository().getQuote(symbolId, token)
-                callback.invoke("${result.successOr(null)}")
+                callback.invoke("${result.successOr(null)?.stringify()}")
             }
         }
     }

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/RequestDelegate.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/RequestDelegate.kt
@@ -1,0 +1,6 @@
+package com.example.fugle_realtime_kotlin_sample.data
+
+interface RequestDelegate {
+    fun name(): String
+    fun start(symbolId: String, token: String, callback: (String) -> Unit)
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
@@ -1,0 +1,80 @@
+package com.example.fugle_realtime_kotlin_sample.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.fugle_realtime_kotlin_sample.ui.components.ActionButton
+
+val terminalTextContent = mutableStateOf("")
+
+@ExperimentalMaterial3Api
+@Composable
+fun FugleActionScreen(title: String) {
+    Scaffold(
+        topBar = { AppBarSection(title) },
+        bottomBar = { BottomNavigationSection() }
+    ) {
+        Box(modifier = Modifier.padding(it)) {
+            TerminalTextSection(text = terminalTextContent.value)
+        }
+    }
+}
+
+@ExperimentalMaterial3Api
+@Composable
+private fun AppBarSection(title: String) {
+    TopAppBar(
+        title = { Text(title) }
+    )
+}
+
+@Composable
+private fun BottomNavigationSection() {
+    val scrollState = rememberScrollState()
+
+    BottomAppBar {
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .horizontalScroll(scrollState),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            repeat(10) {
+                ActionButton(title = "test")
+                Box(modifier = Modifier.width(5.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun TerminalTextSection(text: String) {
+    val scroll = rememberScrollState(0)
+    Text(
+        modifier = Modifier
+            .background(color = Color.Black)
+            .fillMaxSize()
+            .verticalScroll(scroll),
+        text = text,
+        color = Color.White,
+        fontSize = 16.sp,
+    )
+}
+
+@ExperimentalMaterial3Api
+@Preview(showBackground = true)
+@Composable
+fun FugleHttpScreenPreview() {
+    FugleActionScreen("Test Preview")
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
@@ -6,8 +6,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -17,19 +16,29 @@ import androidx.compose.ui.unit.sp
 import com.example.fugle_realtime_kotlin_sample.data.HttpData
 import com.example.fugle_realtime_kotlin_sample.ui.components.ActionButton
 
-val terminalTextContent = mutableStateOf("")
 private const val testSymbolId = "2884"
 private const val testToken = "demo"
 
+/**
+ * @param title 頁面標題
+ * @param actions 要執行的行為  @see HttpData
+ * */
 @ExperimentalMaterial3Api
 @Composable
 fun FugleActionScreen(title: String, actions: List<HttpData>) {
+    var terminalTextContent by remember { mutableStateOf("") }
+
     Scaffold(
         topBar = { AppBarSection(title) },
-        bottomBar = { BottomNavigationSection(actions) }
+        bottomBar = {
+            BottomNavigationSection(
+                actions = actions,
+                actionCallback = { terminalTextContent = it },
+            )
+        }
     ) {
         Box(modifier = Modifier.padding(it)) {
-            TerminalTextSection(text = terminalTextContent.value)
+            TerminalTextSection(text = terminalTextContent)
         }
     }
 }
@@ -43,7 +52,7 @@ private fun AppBarSection(title: String) {
 }
 
 @Composable
-private fun BottomNavigationSection(actions: List<HttpData>) {
+private fun BottomNavigationSection(actions: List<HttpData>, actionCallback: ((String) -> Unit) = {}) {
     val scrollState = rememberScrollState()
 
     BottomAppBar {
@@ -63,7 +72,7 @@ private fun BottomNavigationSection(actions: List<HttpData>) {
                         actions[it].start(
                             symbolId = testSymbolId,
                             token = testToken,
-                            callback = { result -> terminalTextContent.value = result },
+                            callback = { result -> actionCallback.invoke(result) },
                         )
                     })
                 Box(modifier = Modifier.width(5.dp))

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/FugleActionScreen.kt
@@ -14,16 +14,19 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.fugle_realtime_kotlin_sample.data.HttpData
 import com.example.fugle_realtime_kotlin_sample.ui.components.ActionButton
 
 val terminalTextContent = mutableStateOf("")
+private const val testSymbolId = "2884"
+private const val testToken = "demo"
 
 @ExperimentalMaterial3Api
 @Composable
-fun FugleActionScreen(title: String) {
+fun FugleActionScreen(title: String, actions: List<HttpData>) {
     Scaffold(
         topBar = { AppBarSection(title) },
-        bottomBar = { BottomNavigationSection() }
+        bottomBar = { BottomNavigationSection(actions) }
     ) {
         Box(modifier = Modifier.padding(it)) {
             TerminalTextSection(text = terminalTextContent.value)
@@ -40,7 +43,7 @@ private fun AppBarSection(title: String) {
 }
 
 @Composable
-private fun BottomNavigationSection() {
+private fun BottomNavigationSection(actions: List<HttpData>) {
     val scrollState = rememberScrollState()
 
     BottomAppBar {
@@ -50,8 +53,19 @@ private fun BottomNavigationSection() {
                 .horizontalScroll(scrollState),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            repeat(10) {
-                ActionButton(title = "test")
+            repeat(actions.size) {
+                if (it == 0 || it == actions.size - 1) {
+                    Box(modifier = Modifier.width(5.dp))
+                }
+                ActionButton(
+                    title = actions[it].name(),
+                    onClick = {
+                        actions[it].start(
+                            symbolId = testSymbolId,
+                            token = testToken,
+                            callback = { result -> terminalTextContent.value = result },
+                        )
+                    })
                 Box(modifier = Modifier.width(5.dp))
             }
         }
@@ -76,5 +90,5 @@ private fun TerminalTextSection(text: String) {
 @Preview(showBackground = true)
 @Composable
 fun FugleHttpScreenPreview() {
-    FugleActionScreen("Test Preview")
+    FugleActionScreen("Test Preview", actions = listOf())
 }

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/MainScreen.kt
@@ -1,0 +1,70 @@
+package com.example.fugle_realtime_kotlin_sample.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.fugle_realtime_kotlin_sample.data.HttpData
+
+
+@ExperimentalMaterial3Api
+@Composable
+fun MainScreen() {
+    // 這個變數用來追蹤當前選中的項目
+    var selectedTabIndex by remember { mutableStateOf(0) }
+
+
+    Column(modifier = Modifier.fillMaxSize()) {
+        Box(modifier = Modifier.weight(weight = 1f)) {
+            when (selectedTabIndex) {
+                0 -> FugleActionScreen(title = "Http Sample", actions = HttpData.values())
+                1 -> FugleActionScreen(title = "WebSocket Sample", actions = listOf())
+            }
+        }
+        Row(
+            modifier = Modifier
+                .height(56.dp)
+                .fillMaxWidth()
+                .background(Color.Cyan)
+        ) {
+            BottomTabItem(
+                text = "Http",
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { selectedTabIndex = 0 }
+            )
+            BottomTabItem(
+                text = "WebSocket",
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { selectedTabIndex = 1 }
+            )
+        }
+    }
+}
+
+
+@Composable
+private fun BottomTabItem(text: String, modifier: Modifier) {
+    Text(
+        text,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        textAlign = TextAlign.Center,
+    )
+}
+
+@ExperimentalMaterial3Api
+@Preview(showBackground = true)
+@Composable
+fun MainScreenPreview() {
+    MainScreen()
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/MainScreen.kt
@@ -1,17 +1,17 @@
 package com.example.fugle_realtime_kotlin_sample.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Public
+import androidx.compose.material.icons.filled.Webhook
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.fugle_realtime_kotlin_sample.data.HttpData
+import com.example.fugle_realtime_kotlin_sample.ui.components.FTabItem
 
 
 @ExperimentalMaterial3Api
@@ -32,34 +32,23 @@ fun MainScreen() {
             modifier = Modifier
                 .height(56.dp)
                 .fillMaxWidth()
-                .background(Color.Cyan)
         ) {
-            BottomTabItem(
-                text = "Http",
+            FTabItem(
+                title = "Http",
                 modifier = Modifier
                     .weight(1f)
-                    .clickable { selectedTabIndex = 0 }
+                    .clickable { selectedTabIndex = 0 },
+                imageVector = Icons.Default.Public,
             )
-            BottomTabItem(
-                text = "WebSocket",
+            FTabItem(
+                title = "WebSocket",
                 modifier = Modifier
                     .weight(1f)
-                    .clickable { selectedTabIndex = 1 }
+                    .clickable { selectedTabIndex = 1 },
+                imageVector = Icons.Default.Webhook,
             )
         }
     }
-}
-
-
-@Composable
-private fun BottomTabItem(text: String, modifier: Modifier) {
-    Text(
-        text,
-        modifier = modifier
-            .fillMaxSize()
-            .padding(16.dp),
-        textAlign = TextAlign.Center,
-    )
 }
 
 @ExperimentalMaterial3Api

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FButton.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FButton.kt
@@ -1,0 +1,47 @@
+package com.example.fugle_realtime_kotlin_sample.ui.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.fugle_realtime_kotlin_sample.ui.theme.Purple40
+import com.example.fugle_realtime_kotlin_sample.ui.theme.Purple80
+
+@Composable
+fun ActionButton(title: String, onClick: (() -> Unit) = {}) {
+    Box(
+        modifier = Modifier
+            .wrapContentSize()
+            .clip(RoundedCornerShape(50))
+            .border(border = BorderStroke(1.dp, Purple40), shape = RoundedCornerShape(50))
+            .background(Purple80)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            title,
+            color = Color.White,
+            fontSize = 16.sp,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    ActionButton(title = "test")
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FButton.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FButton.kt
@@ -42,6 +42,6 @@ fun ActionButton(title: String, onClick: (() -> Unit) = {}) {
 
 @Preview(showBackground = true)
 @Composable
-fun DefaultPreview() {
+private fun DefaultPreview() {
     ActionButton(title = "test")
 }

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FTabItem.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/components/FTabItem.kt
@@ -1,0 +1,45 @@
+package com.example.fugle_realtime_kotlin_sample.ui.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Webhook
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FTabItem(title: String, modifier: Modifier, imageVector: ImageVector = Icons.Default.Star) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector,
+            contentDescription = title,
+        )
+        Text(
+            text = title,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun DefaultPreview() {
+    FTabItem(
+        title = "WebSocket",
+        modifier = Modifier
+            .height(56.dp)
+            .width(150.dp),
+        imageVector = Icons.Default.Webhook,
+    )
+}

--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/ui/theme/Theme.kt
@@ -34,7 +34,7 @@ private val LightColorScheme = lightColorScheme(
 )
 
 @Composable
-fun FuglerealtimekotlinsampleTheme(
+fun FugleRealtimeKotlinSampleTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
-        compose_version = '1.3.3'
+        compose_version = '1.4.0-beta02'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.0' apply false
-    id 'com.android.library' version '7.3.0' apply false
+    id 'com.android.application' version '7.4.1' apply false
+    id 'com.android.library' version '7.4.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.0' apply false
 }

--- a/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/IntradayExtension.kt
+++ b/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/IntradayExtension.kt
@@ -1,0 +1,17 @@
+package net.makeagoodsoup.fugle_realtime_lib.core.entities
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+fun MetaData.stringify(): String = stringify(this, MetaData::class.java)
+fun QuoteData.stringify(): String = stringify(this, QuoteData::class.java)
+fun ChartData.stringify(): String = stringify(this, ChartData::class.java)
+fun DealtsData.stringify(): String = stringify(this, DealtsData::class.java)
+fun VolumesData.stringify(): String = stringify(this, VolumesData::class.java)
+
+private fun <T> stringify(value: T, type: Class<T>): String {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    // format json
+    val jsonAdapter = moshi.adapter(type)
+    return jsonAdapter.indent("  ").toJson(value)
+}


### PR DESCRIPTION
## Description

更新 Sample App 

## Architecture

<img src="https://user-images.githubusercontent.com/17996728/222944538-c6527a26-b51f-497f-8575-b32a244ddae2.png" width=400 />

#### 1. App Root 頁面改為 MainScreen()

``` kt
@ExperimentalMaterial3Api
class MainActivity : ComponentActivity() {
    override fun onCreate(savedInstanceState: Bundle?) {
       ...
        setContent {
            FuglerealtimekotlinsampleTheme {
                MainScreen() // App Root 頁面改為 MainScreen()
            }
        }
    }
}
```

#### 2. 新增 MainScreen()

``` kt
fun MainScreen() {
   ...
    Column(modifier = Modifier.fillMaxSize()) {
       // 上面填充內容 (Http or WebSocket 頁面)
      Box(modifier = Modifier.weight(weight = 1f)) {
            when (selectedTabIndex) {
                0 -> FugleActionScreen(title = "Http Sample", actions = HttpData.values())
                1 -> FugleActionScreen(title = "WebSocket Sample", actions = listOf())
            }
        }
       // 底部 Tab 切換 Http or WebSocket 
        Row {
            FTabItem( )
            FTabItem( )
        }
    }
}
```

#### 3. 為了重複使用上方的 `Jetpack Compose`，新增 RequestDelegate & HttpData

- 新增 Delegate 定義行為

``` kt
interface RequestDelegate {
    fun name(): String
    fun start(symbolId: String, token: String, callback: (String) -> Unit)
}
```

- 新增 HttpData 並實現 RequestDelegate 行為

``` kt
sealed class HttpData : RequestDelegate {

    @DelicateCoroutinesApi
    object Meta : HttpData() {
        override fun name(): String = "Meta"

        override fun start(symbolId: String, token: String, callback: (String) -> Unit) {
           // todo: get Meta http data
        }
    }

    @DelicateCoroutinesApi
    object Quote : HttpData() {
        override fun name(): String = "Quote"

        override fun start(symbolId: String, token: String, callback: (String) -> Unit) {
           // todo: get Quote http data
        }
    }
    
    // TODO: more Http
}
```

#### 4. 使用 HttpData 產生要顯示的 Action UI

可以參考上方 `2.新增 MainScreen()` 部分

``` kt
@ExperimentalMaterial3Api
@Composable
fun FugleActionScreen(title: String, actions: List<HttpData>) {}

@Composable
private fun BottomNavigationSection(actions: List<HttpData>, actionCallback: ((String) -> Unit) = {}) {
    val scrollState = rememberScrollState()

    BottomAppBar {
        Row {
            repeat(actions.size) {
                // 產生對應 HttpData 里定義的 UI          
            }
     }
}
```

[device-2023-03-05-135910.webm](https://user-images.githubusercontent.com/17996728/222944296-9a803e45-df6e-44c3-a726-455c1d322b00.webm)
