### PR TITLE
[Add] Json stringify

### DIFF
--- a/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
+++ b/app/src/main/java/com/example/fugle_realtime_kotlin_sample/data/HttpData.kt
@@ -3,6 +3,7 @@ package com.example.fugle_realtime_kotlin_sample.data
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
+import net.makeagoodsoup.fugle_realtime_lib.core.entities.stringify
 import net.makeagoodsoup.fugle_realtime_lib.core.repository.FugleHttpRepository
 import net.makeagoodsoup.fugle_realtime_lib.core.repository.successOr
 
@@ -20,7 +21,7 @@ sealed class HttpData : RequestDelegate {
             callback.invoke("InProgress")
             GlobalScope.launch {
                 val result = FugleHttpRepository().getMeta(symbolId, token)
-                callback.invoke("${result.successOr(null)}")
+                callback.invoke("${result.successOr(null)?.stringify()}")
             }
         }
     }
@@ -33,7 +34,7 @@ sealed class HttpData : RequestDelegate {
             callback.invoke("InProgress")
             GlobalScope.launch {
                 val result = FugleHttpRepository().getQuote(symbolId, token)
-                callback.invoke("${result.successOr(null)}")
+                callback.invoke("${result.successOr(null)?.stringify()}")
             }
         }
     }

--- a/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/IntradayExtension.kt
+++ b/fugle_realtime_lib/src/main/java/net/makeagoodsoup/fugle_realtime_lib/core/entities/IntradayExtension.kt
@@ -1,0 +1,17 @@
+package net.makeagoodsoup.fugle_realtime_lib.core.entities
+
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+fun MetaData.stringify(): String = stringify(this, MetaData::class.java)
+fun QuoteData.stringify(): String = stringify(this, QuoteData::class.java)
+fun ChartData.stringify(): String = stringify(this, ChartData::class.java)
+fun DealtsData.stringify(): String = stringify(this, DealtsData::class.java)
+fun VolumesData.stringify(): String = stringify(this, VolumesData::class.java)
+
+private fun <T> stringify(value: T, type: Class<T>): String {
+    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    // format json
+    val jsonAdapter = moshi.adapter(type)
+    return jsonAdapter.indent("  ").toJson(value)
+}


### PR DESCRIPTION
## Description

#### 新增格式化 json response string

``` kt
fun MetaData.stringify(): String = stringify(this, MetaData::class.java)
fun QuoteData.stringify(): String = stringify(this, QuoteData::class.java)
fun ChartData.stringify(): String = stringify(this, ChartData::class.java)
fun DealtsData.stringify(): String = stringify(this, DealtsData::class.java)
fun VolumesData.stringify(): String = stringify(this, VolumesData::class.java)

private fun <T> stringify(value: T, type: Class<T>): String {
    val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
    // format json
    val jsonAdapter = moshi.adapter(type)
    return jsonAdapter.indent("  ").toJson(value)
}
```

#### 使用方法

``` kt
// 取得 MetaData reponse 時，可以使用 stringify() 得到格式化過後的 string
 val formattedString =  FugleHttpRepository().getMeta(symbolId, token).successOr(null)?.stringify() 
 
// 更新 TextView
 TerminalTextSection(text = formattedString)
```

#### 效果

<img src="https://user-images.githubusercontent.com/17996728/222960419-92885ec7-fa50-4713-8b83-e969d8008742.png" width = 300 />
